### PR TITLE
Proportionate Scaling

### DIFF
--- a/test/test.rb
+++ b/test/test.rb
@@ -136,4 +136,26 @@ class FastImageResizeTest < Test::Unit::TestCase
     outfile = FastImage.resize(File.join(FixturePath, "test.png"), 200, 200)
     assert outfile.path =~ /\.png$/
   end
+
+  def test_zero_width_scales_proportionately
+    GoodFixtures.each do |fn, info|
+      File.open(File.join(FixturePath, fn)) do |io|
+        halfHeight = (info[1][1] / 2).round
+        outfile = FastImage.resize(io, 0, halfHeight)
+        newWidth = (halfHeight * info[1][0] / info[1][1]).round
+        assert_equal [newWidth, halfHeight], FastImage.size(outfile)
+      end
+    end
+  end
+
+  def test_zero_height_scales_proportionately
+    GoodFixtures.each do |fn, info|
+      File.open(File.join(FixturePath, fn)) do |io|
+        halfWidth =  (info[1][0] / 2).round
+        outfile = FastImage.resize(io, halfWidth, 0)
+        newHeight = (halfWidth * info[1][1] / info[1][0]).round
+        assert_equal [halfWidth, newHeight], FastImage.size(outfile)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hi sdsykes,

I've made a small modification to this gem to allow proportionate scaling if either the width or height parameter is set to zero.

So with a 360x400 image:

``` ruby
FastImage.resize("foo.jpg", 0, 100)
```

will generate an image with a height of 100 and width of 90 -- it keeps the same aspect ratio of the original image.

I considered changing resize's method signature to move the width and height parameters into the options hash (since they're optional basically) but I didn't want to change the API so drastically :)

I've added tests as well.

Thanks!
Doug
