### PR TITLE
Changing the protocol check in the resize method

### DIFF
--- a/lib/fastimage_resize.rb
+++ b/lib/fastimage_resize.rb
@@ -65,8 +65,8 @@ class FastImage
     if input.respond_to?(:read)
       file_in = read_to_local(input)
     else
-      u = URI.parse(input)
-      if u.scheme == "http" || u.scheme == "https" || u.scheme == "ftp"
+      if input.start_with?("http") || input.start_with?("https") || input.start_with?("ftp")
+        u = URI.parse(file_in)
         file_in = read_to_local(open(u))
       else
         file_in = input.to_s

--- a/lib/fastimage_resize.rb
+++ b/lib/fastimage_resize.rb
@@ -65,7 +65,7 @@ class FastImage
     if input.respond_to?(:read)
       file_in = read_to_local(input)
     else
-      if input.start_with?("http://") || input.start_with?("https://") || input.start_with?("ftp://")
+      if input =~ URI.regexp(['http','https','ftp'])
         u = URI.parse(input)
         file_in = read_to_local(open(u))
       else

--- a/lib/fastimage_resize.rb
+++ b/lib/fastimage_resize.rb
@@ -65,7 +65,7 @@ class FastImage
     if input.respond_to?(:read)
       file_in = read_to_local(input)
     else
-      if input.start_with?("http") || input.start_with?("https") || input.start_with?("ftp")
+      if input.start_with?("http://") || input.start_with?("https://") || input.start_with?("ftp://")
         u = URI.parse(file_in)
         file_in = read_to_local(open(u))
       else

--- a/lib/fastimage_resize.rb
+++ b/lib/fastimage_resize.rb
@@ -66,7 +66,7 @@ class FastImage
       file_in = read_to_local(input)
     else
       if input.start_with?("http://") || input.start_with?("https://") || input.start_with?("ftp://")
-        u = URI.parse(file_in)
+        u = URI.parse(input)
         file_in = read_to_local(open(u))
       else
         file_in = input.to_s

--- a/test/test.rb
+++ b/test/test.rb
@@ -98,7 +98,7 @@ class FastImageResizeTest < Test::Unit::TestCase
   def test_should_raise_for_ico_files
     fn = BadFixtures[2]
     outfile = File.join(PathHere, "fixtures", "resized_" + fn)
-    assert_raises(FastImage::UnknownImageType) do
+    assert_raises(FastImage::FormatNotSupported) do
       FastImage.resize(TestUrl + fn, 20, 20, :outfile=>outfile)
     end
   end

--- a/test/test.rb
+++ b/test/test.rb
@@ -115,6 +115,13 @@ class FastImageResizeTest < Test::Unit::TestCase
     end
   end
   
+  def test_should_resize_names_with_spaces
+    outfile = File.join(PathHere, "fixtures", "resized_test with space.jpg")
+    FastImage.resize(File.join(FixturePath, "test with space.jpg"), 10, 10, :outfile=>outfile)
+    assert File.exists?(outfile)
+    File.unlink outfile
+  end
+
   def test_resized_jpg_is_reasonable_size_for_quality
     outfile = File.join(PathHere, "fixtures", "resized_test.jpg")
     FastImage.resize(File.join(FixturePath, "test.jpg"), 200, 200, :outfile=>outfile)


### PR DESCRIPTION
Tested w/ ruby 2.2.1 - was causing a crash with INVALID URI when attempting to resize a local image with a space in the path name.

This is a simpler check and should prevent that.